### PR TITLE
Fix Azure deploy package path to extracted artifact

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -24,7 +24,12 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to your application's name
-  AZURE_WEBAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
+  # The downloaded artifact is extracted into a directory that matches the artifact name
+  # ("node-app" in this workflow). Deploying the workspace root would therefore
+  # publish a directory structure that wraps the application one level too deep.
+  # Point directly at the extracted artifact directory so the app files are at the root
+  # of the deployed package and the Azure runtime can locate package.json/server files.
+  AZURE_WEBAPP_PACKAGE_PATH: 'node-app'
   NODE_VERSION: '20.x'                # set this to the node version to use
 
 permissions:


### PR DESCRIPTION
## Summary
- point the Azure deployment package path at the downloaded artifact directory so the app deploys from its root
- document why the directory needs to be targeted to avoid nested deployments

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c067ee688324950d224a453aaa0c